### PR TITLE
Configurado docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.4.1-alpine
+
+WORKDIR /app
+
+RUN apk --update add build-base git tzdata nodejs libxslt-dev libxml2-dev imagemagick sqlite sqlite-dev shared-mime-info
+
+COPY Gemfile Gemfile.lock ./
+
+ARG RAILS_ENV
+ENV RACK_ENV=$RAILS_ENV
+
+RUN gem install bundler -v 1.16.1
+
+RUN if [[ "$RAILS_ENV" == "production" ]]; then bundle install --without development test; else bundle install; fi
+
+COPY . ./
+
+EXPOSE 3000
+
+CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
Sem o docker o candidado acaba gastando mais tempo para iniciar o projeto e rodar os testes. Para facilitar foi criado o docker-compose, dessa forma com um `docker-compose up` o candidato pode rodar o projeto já com as dependencias e versões corretas.