### PR TITLE
Change relation between album and player to has_and_belongs_to_many

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,5 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_and_belongs_to_many :players
 
-  validates_presence_of :name
+  validates_presence_of :name, :players
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,5 @@
 class Player < ApplicationRecord
-  has_many :albums
+  has_and_belongs_to_many :albums
 
   validates_presence_of :name
 end

--- a/db/migrate/20220807115022_create_join_table_albums_players.rb
+++ b/db/migrate/20220807115022_create_join_table_albums_players.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateJoinTableAlbumsPlayers < ActiveRecord::Migration[5.2]
+  def up
+    create_join_table :albums, :players do |t|
+      t.index %i[album_id player_id], unique: true
+    end
+
+    connection.execute('insert into albums_players(album_id, player_id) select id, player_id from albums')
+
+    remove_reference :albums, :player
+  end
+
+  def down
+    add_reference :albums, :player, index: true
+
+    connection.execute(
+      'update albums set player_id = (select player_id from albums_players where albums_players.album_id = albums.id)'
+    )
+
+    drop_table :albums_players
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2022_08_07_115022) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
-    t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["player_id"], name: "index_albums_on_player_id"
+  end
+
+  create_table "albums_players", id: false, force: :cascade do |t|
+    t.integer "album_id", null: false
+    t.integer "player_id", null: false
+    t.index ["album_id", "player_id"], name: "index_albums_players_on_album_id_and_player_id", unique: true
   end
 
   create_table "players", force: :cascade do |t|

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,17 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
+  players:
+    - shakira
+    - 50cent
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
+  players:
+    - shakira
+    - 50cent
 
 fixation:
   name: She Wolf
-  player: shakira
+  players:
+    - shakira
+    - 50cent

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -1,20 +1,20 @@
 require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
-  test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
+  test 'valid album' do
+    album = Album.new(name: 'Peligro', players: [players(:shakira)])
     assert album.valid?
   end
 
-  test "presence of name" do
+  test 'presence of name' do
     album = Album.new
     assert_not album.valid?
     assert_not_empty album.errors[:name]
   end
 
-  test "presence of player" do
+  test 'presence at least one player' do
     album = Album.new
     assert_not album.valid?
-    assert_not_empty album.errors[:player]
+    assert_not_empty album.errors[:players]
   end
 end


### PR DESCRIPTION
## Descrição
#### Problema
Transforme a relacão 1 para N entre Player e Album em uma relação N para N. Precisamos de testes senão o chato do agilista vai brigar conosco!

#### Solução
- Criar join table com as chaves de players e albums
- Importar todos os dados
- Remover chave estrangeira de albums
- Ajustar testes

PS: Acredito não ser viável usar o active record na migração de dados, nos deploys para outros ambientes, por conta das alterações nos models.