### PR TITLE
Change album artist relationship

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -215,4 +217,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,6 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_many :player_albums
+  has_many :players, through: :player_albums
 
   validates_presence_of :name
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,6 @@
 class Player < ApplicationRecord
-  has_many :albums
+  has_many :player_albums
+  has_many :albums, through: :player_albums
 
   validates_presence_of :name
 end

--- a/app/models/player_album.rb
+++ b/app/models/player_album.rb
@@ -1,0 +1,4 @@
+class PlayerAlbum < ApplicationRecord
+  belongs_to :player
+  belongs_to :album
+end

--- a/db/migrate/20220911211437_create_player_albums.rb
+++ b/db/migrate/20220911211437_create_player_albums.rb
@@ -1,0 +1,10 @@
+class CreatePlayerAlbums < ActiveRecord::Migration[5.2]
+  def change
+    create_table :player_albums do |t|
+      t.belongs_to :player, index: true
+      t.belongs_to :album, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220911212223_remove_player_from_album.rb
+++ b/db/migrate/20220911212223_remove_player_from_album.rb
@@ -1,0 +1,5 @@
+class RemovePlayerFromAlbum < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :albums, :player, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2022_09_11_212223) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
-    t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["player_id"], name: "index_albums_on_player_id"
+  end
+
+  create_table "player_albums", force: :cascade do |t|
+    t.integer "player_id"
+    t.integer "album_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["album_id"], name: "index_player_albums_on_album_id"
+    t.index ["player_id"], name: "index_player_albums_on_player_id"
   end
 
   create_table "players", force: :cascade do |t|

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,8 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
 
 fixation:
   name: She Wolf
-  player: shakira

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
   test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
+    album = Album.new(name: 'Peligro')
     assert album.valid?
   end
 
@@ -12,9 +12,12 @@ class AlbumTest < ActiveSupport::TestCase
     assert_not_empty album.errors[:name]
   end
 
-  test "presence of player" do
-    album = Album.new
-    assert_not album.valid?
-    assert_not_empty album.errors[:player]
+  test "has many players" do
+    album = Album.new(name: 'Afrociberdelia')
+    album.save!
+    album.players.create(name: 'Chico Science')
+    album.players.create(name: 'Paralamas do Sucesso')
+
+    assert_equal 2, album.players.count
   end
 end

--- a/test/models/player_test.rb
+++ b/test/models/player_test.rb
@@ -11,4 +11,13 @@ class PlayerTest < ActiveSupport::TestCase
     assert_not player.valid?
     assert_not_empty player.errors[:name]
   end
+
+  test "has many albums" do
+    player = Player.new(name: 'João Gordo')
+    player.save!
+    player.albums.create(name: 'Crucificados Pelo Sistema')
+    player.albums.create(name: 'Anarcofobia')
+
+    assert_equal 2, player.albums.count
+  end
 end


### PR DESCRIPTION
### Descrição

Da forma como estava implementado o relacionamento entre os models, um álbum só poderia estar relacionado a uma artista, inviabilizando álbuns com parcerias, para resolver tive que criar uma classe/tabela que contenha as duas chaves álbum e artista, ajustando os models Album e Player de N para N através dessa classe intermediária PlayerAlbum para mapear as chaves.

### Issue tracker

\[Link para o card no Kanbanize.\]

### Screenshots (para mudanças de UI, se houver)

![Captura de tela de 2022-09-12 09-06-04](https://user-images.githubusercontent.com/24991856/189649732-2cb4a5db-4d8f-4ce3-9f22-f45a605ae8da.png)

![Captura de tela de 2022-09-12 09-09-06](https://user-images.githubusercontent.com/24991856/189649755-6441b894-df47-40b0-aa1e-73e9013f3b45.png)

### Links e observações

\[Links úteis que podem contextualizar e ajudar o revisor, por exemplo para a página de uma dependência que escolheu adicionar, ou um código que se inspirou, ou documentação externa (docs de uma API, do Vue, do Rails, etc).\]

https://guides.rubyonrails.org/v5.2/association_basics.html#the-has-many-through-association

### Checklist para poder mergear

- [X] O código do PR inclui (ou já possui) testes para o código nele
- [X] Os checks de linters estão passando
- [X] Os checks de testes estão passando
