### PR TITLE
Alterar relação entre artistas e álbuns de 1xN para NxN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "activerecord-import", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -215,4 +217,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 5.2.0)
       activesupport (= 5.2.0)
       arel (>= 9.0)
+    activerecord-import (1.4.1)
+      activerecord (>= 4.2)
     activestorage (5.2.0)
       actionpack (= 5.2.0)
       activerecord (= 5.2.0)
@@ -156,6 +158,8 @@ GEM
     selenium-webdriver (3.13.1)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -194,6 +198,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import (~> 1.4)
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15, < 4.0)
@@ -205,6 +210,7 @@ DEPENDENCIES
   rails (~> 5.2.0)
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers (~> 4.5)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,6 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_many :authorships
+  has_many :players, through: :authorships
 
-  validates_presence_of :name
+  validates_presence_of :name, :players
 end

--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -1,0 +1,5 @@
+class Authorship < ApplicationRecord
+  belongs_to :album
+  belongs_to :player
+end
+  

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,6 @@
 class Player < ApplicationRecord
-  has_many :albums
+  has_many :authorships
+  has_many :albums, through: :authorships
 
   validates_presence_of :name
 end

--- a/db/migrate/20221122192830_create_join_table_authorships.rb
+++ b/db/migrate/20221122192830_create_join_table_authorships.rb
@@ -1,0 +1,16 @@
+class CreateJoinTableAuthorships < ActiveRecord::Migration[5.2]
+  def up
+    create_join_table :albums, :players, table_name: :authorships
+
+    Album.select(:id, :player_id).find_in_batches do |albums|
+      Authorship.import([:album_id, :player_id], albums.pluck(:id, :player_id), validate: false)
+    end
+
+    add_index :authorships, :album_id
+    add_index :authorships, :player_id
+  end
+
+  def down
+    drop_table :authorships
+  end
+end

--- a/db/migrate/20221122195147_remove_column_player_id_from_albums.rb
+++ b/db/migrate/20221122195147_remove_column_player_id_from_albums.rb
@@ -1,0 +1,18 @@
+class RemoveColumnPlayerIdFromAlbums < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :albums, :player_id, :integer
+  end
+
+  def down
+    add_column :albums, :player_id, :integer
+
+    if Album.method_defined? :authorships
+      Album.includes(:authorships).find_each do |album|
+        album.update_column(:player_id, album.authorships.first.player_id)
+      end
+    end
+
+    add_foreign_key :albums, :players
+    add_index :albums, :player_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2022_11_22_195147) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
-    t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["player_id"], name: "index_albums_on_player_id"
+  end
+
+  create_table "authorships", id: false, force: :cascade do |t|
+    t.integer "album_id", null: false
+    t.integer "player_id", null: false
+    t.index ["album_id"], name: "index_authorships_on_album_id"
+    t.index ["player_id"], name: "index_authorships_on_player_id"
   end
 
   create_table "players", force: :cascade do |t|

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,8 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
 
 fixation:
   name: She Wolf
-  player: shakira

--- a/test/fixtures/authorships.yml
+++ b/test/fixtures/authorships.yml
@@ -1,0 +1,12 @@
+fijacion:
+  album: fijacion
+  player: shakira
+
+fixation:
+  album: fixation
+  player: shakira
+
+fixation:
+  album: fixation
+  player: shakira
+

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
   test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
+    album = Album.new(name: 'Peligro', players: [players(:shakira), players(:beyonce)])
     assert album.valid?
   end
 
@@ -12,9 +12,9 @@ class AlbumTest < ActiveSupport::TestCase
     assert_not_empty album.errors[:name]
   end
 
-  test "presence of player" do
+  test "presence of players" do
     album = Album.new
     assert_not album.valid?
-    assert_not_empty album.errors[:player]
+    assert_not_empty album.errors[:players]
   end
 end

--- a/test/models/authorship_test.rb
+++ b/test/models/authorship_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class AuthorshipTest < ActiveSupport::TestCase
+  test "valid authorship" do
+    authorship = Authorship.new(album: albums(:fixation), player: players(:shakira))
+    assert authorship.valid?
+  end
+
+  test "presence of album" do
+    authorship = Authorship.new
+    assert_not authorship.valid?
+    assert_not_empty authorship.errors[:album]
+  end
+
+  test "presence of player" do
+    authorship = Authorship.new
+    assert_not authorship.valid?
+    assert_not_empty authorship.errors[:player]
+  end
+end


### PR DESCRIPTION
### Descrição

Atualmente o sistema comporta um artista por álbum, mas cantores começaram a lançar álbuns em parceria e com isso precisamos conseguir registrar mais de um artista por álbum, sendo necessário tecnicamente alterar uma relação 1xN para NxN. Além disso, precisamos levar em consideração que a mudança do modelo do banco e a migração desses dados pode demandar um tempo considerável e com isso é necessário que a solução leve em consideração a performance dessa mudança em um ambiente de produção.

A solução implementada possui 3 alteração principais:

1. Criação de uma tabela intermediária nomeada de autoria (authorship) que possibilita a relação NxN.
2. Criação de um lógica de migração dos dados da relação 1xN para NxN por meio da utilização da consulta em batches (conjuntos de registros) fazendo inserções em grupos ao invés de todos de uma vez, além da utilização da gem `activerecord-import` que possibilidade uma migração dos dados de forma otimizada por criar apenas um único insert para cada batch (conjunto de registros), ao invés da forma padrão do rails de um insert para cada registro.
3. Remoção da coluna da relação 1xN que se torna desnecessária
4. Caso seja necessário retornar a estrutura anterior, foi garantido não apenas o retorno da estrutura, como também dos dados.

### Links e observações

[active_record-import](https://github.com/zdennis/activerecord-import) Gem utilizada para migração dos dados.

### Checklist para poder mergear

- [x] O código do PR inclui (ou já possui) testes para o código nele
- [ ] Os checks de linters estão passando
- [x] Os checks de testes estão passando
