### PR TITLE
Refactor player and album relation from one to many for many to many

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -215,4 +217,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,6 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_many :player_albums
+  has_many :players, through: :player_albums
 
-  validates_presence_of :name
+  validates_presence_of :name, :players
 end

--- a/app/models/player_album.rb
+++ b/app/models/player_album.rb
@@ -1,0 +1,4 @@
+class PlayerAlbum < ApplicationRecord
+  belongs_to :player
+  belongs_to :album
+end

--- a/db/migrate/20221119233903_create_join_table_players_albums.rb
+++ b/db/migrate/20221119233903_create_join_table_players_albums.rb
@@ -1,0 +1,12 @@
+class CreateJoinTablePlayersAlbums < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :players, :albums, table_name: :player_albums do |t|
+      t.index [:player_id, :album_id]
+      t.index [:album_id, :player_id]
+    end
+
+    Album.select(:id, :player_id).find_each do |album|
+      PlayerAlbum.create(album_id: album.id, player_id: album.player_id)
+    end
+  end
+end

--- a/db/migrate/20221119234229_remove_player_from_albums.rb
+++ b/db/migrate/20221119234229_remove_player_from_albums.rb
@@ -1,0 +1,5 @@
+class RemovePlayerFromAlbums < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :albums, :player
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2022_11_19_234229) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
-    t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["player_id"], name: "index_albums_on_player_id"
+  end
+
+  create_table "player_albums", id: false, force: :cascade do |t|
+    t.integer "player_id", null: false
+    t.integer "album_id", null: false
+    t.index ["album_id", "player_id"], name: "index_player_albums_on_album_id_and_player_id"
+    t.index ["player_id", "album_id"], name: "index_player_albums_on_player_id_and_album_id"
   end
 
   create_table "players", force: :cascade do |t|

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,8 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
 
-fixation:
+she_wolf:
   name: She Wolf
-  player: shakira

--- a/test/fixtures/player_albums.yml
+++ b/test/fixtures/player_albums.yml
@@ -1,0 +1,11 @@
+fijacion:
+  album: fijacion
+  player: shakira
+
+fixation:
+  album: fixation
+  player: shakira
+
+she_wolf:
+  album: she_wolf
+  player: shakira

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -2,7 +2,12 @@ require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
   test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
+    album = Album.new(name: 'Peligro', players: [players(:shakira)])
+    assert album.valid?
+  end
+
+  test "valid album with multiple players" do
+    album = Album.new(name: 'Foo', players: [players(:shakira), players(:madonna)])
     assert album.valid?
   end
 
@@ -12,9 +17,9 @@ class AlbumTest < ActiveSupport::TestCase
     assert_not_empty album.errors[:name]
   end
 
-  test "presence of player" do
+  test "presence of players" do
     album = Album.new
     assert_not album.valid?
-    assert_not_empty album.errors[:player]
+    assert_not_empty album.errors[:players]
   end
 end

--- a/test/models/player_album_test.rb
+++ b/test/models/player_album_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class PlayerAlbumTest < ActiveSupport::TestCase
+  test "valid player_album" do
+    player_album = PlayerAlbum.new(album: albums(:fijacion), player: players(:shakira))
+    assert player_album.valid?
+  end
+
+  test "presence of album" do
+    player_album = PlayerAlbum.new
+    assert_not player_album.valid?
+    assert_not_empty player_album.errors[:album]
+  end
+
+  test "presence of player" do
+    player_album = PlayerAlbum.new
+    assert_not player_album.valid?
+    assert_not_empty player_album.errors[:player]
+  end
+end


### PR DESCRIPTION
### Descrição

O sistema possui dois modelos: Player e Album e eles tem uma relação 1:N. E é necessário que essa relação seja alterada para N:N.

Para isso foi criada uma tabela intermediária PlayerAlbums, a migração dos dados que anteriormente eram 1:N para essa nova tabela que contém tanto o player_id quanto o album_id, e a remoção da antiga relação de player que existia em album.