### PR TITLE
Update Relationship Table Album and Player

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,6 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  #belongs_to :player
+  has_and_belongs_to_many :players
 
   validates_presence_of :name
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,6 @@
 class Player < ApplicationRecord
-  has_many :albums
+  #has_many :albums
+  has_and_belongs_to_many :albums
 
   validates_presence_of :name
 end

--- a/db/migrate/20221205024030_create_join_table_player_album.rb
+++ b/db/migrate/20221205024030_create_join_table_player_album.rb
@@ -1,0 +1,8 @@
+class CreateJoinTablePlayerAlbum < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :players, :albums do |t|
+      # t.index [:player_id, :album_id]
+      # t.index [:album_id, :player_id]
+    end
+  end
+end

--- a/db/migrate/20221205145806_remove_player_id_column_to_album.rb
+++ b/db/migrate/20221205145806_remove_player_id_column_to_album.rb
@@ -1,0 +1,8 @@
+class RemovePlayerIdColumnToAlbum < ActiveRecord::Migration[5.2]
+  empty_column = Album.where(player_id: !nil)
+  if empty_column.blank?
+    def change
+      remove_column :albums, :player_id
+    end
+  end
+end

--- a/lib/tasks/update_join_table.rake
+++ b/lib/tasks/update_join_table.rake
@@ -1,0 +1,13 @@
+namespace :update_join_table do
+  desc "TODO"
+  task tranfer_albums: :environment do
+    albuns = Album.all
+    albuns.each do |album|
+      @album = album.update!(player_ids: [album.player_id])
+      if @album == true && !album.player_id.nil?
+        album.player_id = nil
+        album.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Descrição

Adicionado tabela para ligação N:N, tambem foi adiconado uma rake para migrar as informações para a nova tabela.
Após executar a rake, pode ser executado a migration para remover o player_id da tabela album

### Checklist para poder mergear

- [ ] O código do PR inclui (ou já possui) testes para o código nele
- [ ] Os checks de linters estão passando
- [ ] Os checks de testes estão passando
