### PR TITLE
Tech Test 2 [Candidato - Paulo Henrique Tada]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.4.1-alpine
+
+RUN apk add --update build-base nodejs tzdata postgresql-dev postgresql-client libxslt-dev libxml2-dev imagemagick sqlite-dev shared-mime-info
+
+CMD tail -f /dev/null

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'awesome_print'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    awesome_print (1.9.2)
     bindex (0.5.0)
     bootsnap (1.3.1)
       msgpack (~> 1.0)
@@ -96,7 +97,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -192,6 +195,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15, < 4.0)

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,5 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_and_belongs_to_many :players
 
   validates_presence_of :name
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,5 @@
 class Player < ApplicationRecord
-  has_many :albums
+  has_and_belongs_to_many :albums
 
   validates_presence_of :name
 end

--- a/db/migrate/20230613225357_create_players_albums.rb
+++ b/db/migrate/20230613225357_create_players_albums.rb
@@ -1,0 +1,8 @@
+class CreatePlayersAlbums < ActiveRecord::Migration[5.2]
+  def change
+    create_table :albums_players, id: false do |t|
+      t.belongs_to :player
+      t.belongs_to :album
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2023_06_13_225357) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,13 @@ ActiveRecord::Schema.define(version: 2018_08_02_203647) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["player_id"], name: "index_albums_on_player_id"
+  end
+
+  create_table "albums_players", id: false, force: :cascade do |t|
+    t.integer "player_id"
+    t.integer "album_id"
+    t.index ["album_id"], name: "index_albums_players_on_album_id"
+    t.index ["player_id"], name: "index_albums_players_on_player_id"
   end
 
   create_table "players", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.6'
+
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/app
+

--- a/lib/tasks/simulate_data.rake
+++ b/lib/tasks/simulate_data.rake
@@ -1,0 +1,30 @@
+namespace :db do
+  desc 'Creates data pre moving migration'
+  task simulate_data: :environment do
+    player_1 = Player.create!(name: "Player 1")
+    player_2 = Player.create!(name: "Player 2")
+
+    album_1 = Album.create!(name: "Album 1-1")
+    album_1.update_column(:player_id, player_1.id)
+    album_2 = Album.create!(name: "Album 2-1")
+    album_2.update_column(:player_id, player_1.id)
+    album_3 = Album.create!(name: "Album 3-1")
+    album_3.update_column(:player_id, player_1.id)
+
+    album_4 = Album.create!(name: "Album 1-2")
+    album_4.update_column(:player_id, player_2.id)
+    album_5 = Album.create!(name: "Album 2-2")
+    album_5.update_column(:player_id, player_2.id)
+  end
+
+  desc 'Migrate album and player to many_to_many'
+  task migrate_album_player: :environment do
+    sql = <<-SQL
+      INSERT INTO albums_players (album_id, player_id)
+        SELECT id, player_id
+        FROM albums
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,15 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
+  players: [shakira]
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
+  players: [shakira]
+
+she_wolf:
+  name: She Wolf
+  players: [shakira]
 
 fixation:
-  name: She Wolf
-  player: shakira
+  name: Beautiful Liar
+  players: [shakira, beyonce]

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
   test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
+    album = Album.new(name: 'Peligro', players: [players(:shakira)])
     assert album.valid?
   end
 
@@ -12,9 +12,9 @@ class AlbumTest < ActiveSupport::TestCase
     assert_not_empty album.errors[:name]
   end
 
-  test "presence of player" do
-    album = Album.new
-    assert_not album.valid?
-    assert_not_empty album.errors[:player]
+  test "players association" do
+    albums_players = [players(:shakira), players(:beyonce)]
+    album = Album.new(name: 'Beautiful Liar', players: albums_players)
+    assert_not_empty album.players
   end
 end

--- a/test/models/player_test.rb
+++ b/test/models/player_test.rb
@@ -11,4 +11,10 @@ class PlayerTest < ActiveSupport::TestCase
     assert_not player.valid?
     assert_not_empty player.errors[:name]
   end
+
+  test "album association" do
+    players_albums = [albums(:fijacion), albums(:she_wolf)]
+    player = Player.new(name: 'Shakira', albums: players_albums)
+    assert_not_empty player.albums
+  end
 end


### PR DESCRIPTION
### Descrição

Alteração de associação entre Player e Album de 1-N para N-N. Utilizando o `have_an_belongs_to_many` do Rails. Em uma situação real, o ideal é este PR ser dividido em 2 etapas.

- Criação e migração dos dados para o novo modelo, ou seja, run das migrations e rake tasks
- Alteração do código para utilizar a nova associação

A depender da estrutura do banco de produção, a coluna com a chave de `Player` em `Album` pode ou não ser removida. No caso, considero que o campo ñ é obrigatório ou utilizado fora do framework.

#### Alterações

- Migration para criação de uma tabela de relação N-N `albums_players`
- Remoção do `belongs_to` e `has_many` entre `Player` e `Album`
- Inserção de `have_and_belongs_to_many` entre `Player` e `Album`
- Rake task para simulação de dados locais com associações já existentes em banco
- Rake task para migrar os dados de associações existentes para nova tabela `albums_players`
- Refactor de testes para nova associação

### Issue tracker

[Descrição da vaga](https://clicksign.gupy.io/jobs/4694504)
