### PR TITLE
feat: Refactor Album/Player association from 1-N to N-N

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -96,7 +103,6 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -199,6 +205,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mimemagic!
   puma (~> 3.12)
   rails (~> 5.2.0)
   sass-rails (~> 5.0)
@@ -215,4 +222,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,6 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_many :partner_artists, class_name: 'AlbumsPlayer', dependent: :destroy
+  has_many :players, through: :partner_artists
 
-  validates_presence_of :name
+  validates :name, :players, presence: true
 end

--- a/app/models/albums_player.rb
+++ b/app/models/albums_player.rb
@@ -1,0 +1,8 @@
+class AlbumsPlayer < ApplicationRecord
+  belongs_to :album
+  belongs_to :player
+
+  validates :album_id, uniqueness: { scope: :player_id }
+
+  validates :player_id, uniqueness:  { scope: :album_id }
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,6 @@
 class Player < ApplicationRecord
-  has_many :albums
+  has_many :partner_artists, class_name: 'AlbumsPlayer', dependent: :destroy
+  has_many :albums, through: :partner_artists
 
   validates_presence_of :name
 end

--- a/db/migrate/20230623015339_create_albums_players.rb
+++ b/db/migrate/20230623015339_create_albums_players.rb
@@ -1,0 +1,11 @@
+class CreateAlbumsPlayers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :albums_players do |t|
+      t.references :album, foreign_key: true
+      t.references :player, foreign_key: true
+      t.index [:player_id, :album_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230623015745_remove_player_id_from_albums.rb
+++ b/db/migrate/20230623015745_remove_player_id_from_albums.rb
@@ -1,0 +1,9 @@
+class RemovePlayerIdFromAlbums < ActiveRecord::Migration[5.2]
+  def change
+    Album.find_each do |album|
+      album.partner_artists.create(player: album.player)
+    end
+
+    remove_column :albums, :player_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2023_06_23_015745) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "albums_players", force: :cascade do |t|
+    t.integer "album_id"
     t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["player_id"], name: "index_albums_on_player_id"
+    t.index ["album_id"], name: "index_albums_players_on_album_id"
+    t.index ["player_id", "album_id"], name: "index_albums_players_on_player_id_and_album_id", unique: true
+    t.index ["player_id"], name: "index_albums_players_on_player_id"
   end
 
   create_table "players", force: :cascade do |t|

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,20 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
 
 fixation:
   name: She Wolf
-  player: shakira
+
+one:
+  id: 1
+  name: Toxicity
+
+two:
+  id: 2
+  name: The Next Logical Progression
+
+three:
+  id: 3
+  name: Let Them Talk

--- a/test/fixtures/albums_players.yml
+++ b/test/fixtures/albums_players.yml
@@ -1,0 +1,11 @@
+one:
+  album_id: 1
+  player_id: 1
+
+two:
+  album_id: 2
+  player_id: 2
+
+three:
+  album_id: 3
+  player_id: 3

--- a/test/fixtures/players.yml
+++ b/test/fixtures/players.yml
@@ -3,3 +3,15 @@ beyonce:
 
 shakira:
   name: Shakira
+
+one:
+  id: 1
+  name: System Of A Down
+
+two:
+  id: 2
+  name: Gift of Gab
+
+three:
+  id: 3
+  name: Hugh Laurie

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -1,11 +1,6 @@
 require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
-  test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
-    assert album.valid?
-  end
-
   test "presence of name" do
     album = Album.new
     assert_not album.valid?
@@ -15,6 +10,16 @@ class AlbumTest < ActiveSupport::TestCase
   test "presence of player" do
     album = Album.new
     assert_not album.valid?
-    assert_not_empty album.errors[:player]
+  end
+
+  test 'album should not have the same player associated' do
+    player1 = Player.new(name: "Player1")
+    player2 = Player.new(name: "Player2")
+    album = Album.new(name: "Album")
+
+    album.players << player1
+    album.players << player2
+    album.players << player1 # Tentativa de adicionar o mesmo player novamente
+    assert_raise(ActiveRecord::RecordInvalid) { album.save! }
   end
 end


### PR DESCRIPTION
### Descrição

Transforme a relacão 1 para N entre Player e Album em uma relação N para N.

### Solução

Unrelated: Foi necessario adicionar a referência à gem Mimemagic para conseguir rodar o projeto corretamente
Foi criada primeiramente a tabela de ligação entre o album e o player
Em seguida realizei a migração de dados da relação antiga para nova antes da remoção da coluna `player_id` na tabela de albuns
Em seguida ajustei alguns dos testes, fiz algo superficial pois nunca mexi diretamente com testes fora do RSpec.

### Considerações
Não me importei em fazer a migração dos dados diretamente numa migration pois no caso de exemplo não haviam registros no banco, porém em uma aplicação em produção isso deve ser lidado de forma separada para evitar um lock no banco durante a execução da migração. 