### PR TITLE
Alexandre Magro - Teste 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -215,4 +217,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,7 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_many :authorships
+  has_many :players, through: :authorships 
 
-  validates_presence_of :name
+  validates :name, presence: true
+  validates :authorships, presence: true
 end

--- a/app/models/authorship.rb
+++ b/app/models/authorship.rb
@@ -1,0 +1,4 @@
+class Authorship < ApplicationRecord
+  belongs_to :player
+  belongs_to :album
+end

--- a/db/migrate/20230625224808_create_authorships.rb
+++ b/db/migrate/20230625224808_create_authorships.rb
@@ -1,0 +1,8 @@
+class CreateAuthorships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :authorships do |t|
+      t.references :player, foreign_key: true
+      t.references :album, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20230625224838_populate_authorship.rb
+++ b/db/migrate/20230625224838_populate_authorship.rb
@@ -1,0 +1,7 @@
+class PopulateAuthorship < ActiveRecord::Migration[5.2]
+  def up
+    Album.find_each do |album|
+      Authorship.create player: album.player, album: album
+    end
+  end
+end

--- a/db/migrate/20230625225242_remove_player_id_from_album.rb
+++ b/db/migrate/20230625225242_remove_player_id_from_album.rb
@@ -1,0 +1,5 @@
+class RemovePlayerIdFromAlbum < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :albums, :player, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2023_06_25_225242) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
-    t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["player_id"], name: "index_albums_on_player_id"
+  end
+
+  create_table "authorships", force: :cascade do |t|
+    t.integer "player_id"
+    t.integer "album_id"
+    t.index ["album_id"], name: "index_authorships_on_album_id"
+    t.index ["player_id"], name: "index_authorships_on_player_id"
   end
 
   create_table "players", force: :cascade do |t|

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,8 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
 
 fixation:
   name: She Wolf
-  player: shakira

--- a/test/fixtures/authorships.yml
+++ b/test/fixtures/authorships.yml
@@ -1,0 +1,11 @@
+shakira:
+  player: shakira
+  album: fijacion
+
+shakira:
+  player: shakira
+  album: fixation
+
+shakira:
+  player: shakira
+  album: fixation

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
   test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
+    album = Album.new(name: 'Peligro', players: [players(:shakira)])
     assert album.valid?
   end
 
@@ -12,9 +12,10 @@ class AlbumTest < ActiveSupport::TestCase
     assert_not_empty album.errors[:name]
   end
 
-  test "presence of player" do
+  test "presence of authorships" do
     album = Album.new
+
     assert_not album.valid?
-    assert_not_empty album.errors[:player]
+    assert_includes album.errors.details[:authorships], { error: :blank }
   end
 end

--- a/test/models/authorship_test.rb
+++ b/test/models/authorship_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class AuthorshipTest < ActiveSupport::TestCase
+  test "presence of player" do
+    authorship = Authorship.new
+    assert_not authorship.valid?
+    assert_not_empty authorship.errors[:player]
+  end
+
+  test "presence of album" do
+    authorship = Authorship.new
+    assert_not authorship.valid?
+    assert_not_empty authorship.errors[:album]
+  end
+end


### PR DESCRIPTION
### Descrição

Solução Teste 2

### Links e observações

- Alteração na `Gemfile.lock` devido a gem antiga que foi removida do RubyGems;
- Optei por usar um model como join table, pois para esse caso acho mais flexível (até se mais tarde fosse o caso de adicionar mais informações à esta como autoria principal e afins), mas também uma outra solução seria apenas usar uma tabela `albums_players` e usar `has_and_belongs_to_many` nos dois models relacionados;