### PR TITLE
feat: mudança de relacionamento 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'mimemagic', '~> 0.3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -96,7 +97,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -105,6 +108,9 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.2)
     puma (3.12.6)
     rack (2.2.3)
@@ -199,6 +205,8 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mimemagic (~> 0.3.10)
+  pry
   puma (~> 3.12)
   rails (~> 5.2.0)
   sass-rails (~> 5.0)
@@ -215,4 +223,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.1
+   2.2.33

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,6 @@
 class Album < ApplicationRecord
-  belongs_to :player
+  has_and_belongs_to_many :players
 
   validates_presence_of :name
+  validates :players, length: { minimum: 1, message: "must have at least one" }
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,5 @@
 class Player < ApplicationRecord
-  has_many :albums
+  has_and_belongs_to_many :albums
 
   validates_presence_of :name
 end

--- a/db/migrate/20250521212538_create_albums_players_join_table.rb
+++ b/db/migrate/20250521212538_create_albums_players_join_table.rb
@@ -1,0 +1,28 @@
+class CreateAlbumsPlayersJoinTable < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :albums, :players, id: false do |t|
+      t.index [:album_id, :player_id], unique: true
+      t.index [:player_id, :album_id], unique: true
+    end
+
+    add_foreign_key :albums_players, :albums, column: :album_id
+    add_foreign_key :albums_players, :players, column: :player_id
+
+    reversible do |dir|
+      dir.up do
+        migrate_album_players_data
+      end
+    end
+  end
+
+  private
+
+  def migrate_album_players_data
+    Album.where.not(player_id: nil).find_each do |album|
+      execute <<-SQL.squish
+        INSERT INTO albums_players (album_id, player_id)
+        VALUES (#{album.id}, #{album.player_id})
+      SQL
+    end
+  end
+end

--- a/db/migrate/20250521212814_alter_table_drop_reference_player_on_albums.rb
+++ b/db/migrate/20250521212814_alter_table_drop_reference_player_on_albums.rb
@@ -1,0 +1,5 @@
+class AlterTableDropReferencePlayerOnAlbums < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :albums, :player_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2025_05_21_212814) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
-    t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["player_id"], name: "index_albums_on_player_id"
+  end
+
+  create_table "albums_players", id: false, force: :cascade do |t|
+    t.integer "album_id", null: false
+    t.integer "player_id", null: false
+    t.index ["album_id", "player_id"], name: "index_albums_players_on_album_id_and_player_id", unique: true
+    t.index ["player_id", "album_id"], name: "index_albums_players_on_player_id_and_album_id", unique: true
   end
 
   create_table "players", force: :cascade do |t|

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,11 +1,17 @@
 fijacion:
   name: Fijación Oral, Vol. 1
-  player: shakira
 
 fixation:
   name: Oral Fixation, Vol. 2
-  player: shakira
 
 fixation:
   name: She Wolf
-  player: shakira
+
+peligro:
+  name: Peligro
+
+confessions:
+  name: Confessions on a Dance Floor
+
+lemonade:
+  name: Lemonade

--- a/test/fixtures/players.yml
+++ b/test/fixtures/players.yml
@@ -3,3 +3,7 @@ beyonce:
 
 shakira:
   name: Shakira
+
+madonna:
+  name: Madonna
+  

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -2,8 +2,24 @@ require 'test_helper'
 
 class AlbumTest < ActiveSupport::TestCase
   test "valid album" do
-    album = Album.new(name: 'Peligro', player: players(:shakira))
+    album = Album.new(name: albums(:peligro).name, players: [ players(:shakira) ])
     assert album.valid?
+    assert_equal album.name, albums(:peligro).name
+    assert_includes album.players, players(:shakira)
+  end
+
+  test "album can have one player" do
+    album = Album.new(name: albums(:fixation).name, players: [ players(:shakira) ])
+    assert album.valid?
+    assert_equal 1, album.players.size
+    assert_includes album.players, players(:shakira)
+  end
+
+  test "album can have multiple players" do    
+    album = Album.new(name: albums(:confessions).name, players: [ players(:madonna), players(:shakira) ])
+    assert album.valid?
+    assert_equal 2, album.players.size
+    assert_equal [players(:madonna), players(:shakira)], album.players
   end
 
   test "presence of name" do
@@ -12,9 +28,9 @@ class AlbumTest < ActiveSupport::TestCase
     assert_not_empty album.errors[:name]
   end
 
-  test "presence of player" do
+  test "presence of players" do
     album = Album.new
     assert_not album.valid?
-    assert_not_empty album.errors[:player]
+    assert_not_empty album.errors[:players]
   end
 end

--- a/test/models/player_test.rb
+++ b/test/models/player_test.rb
@@ -2,8 +2,27 @@ require 'test_helper'
 
 class PlayerTest < ActiveSupport::TestCase
   test "valid player" do
-    player = Player.new(name: 'Madonna')
+    player = Player.new(name: players(:madonna).name)
     assert player.valid?
+  end
+
+  test "player can have one album" do
+    player = Player.new(name: players(:shakira).name, albums: [ albums(:peligro) ])
+    assert_equal 1, player.albums.size
+    assert_includes player.albums, albums(:peligro)
+  end
+
+  test "player can have multiple albums" do            []    
+    player = Player.new(name: players(:shakira).name, albums: [ albums(:confessions), albums(:peligro) ])
+    assert_equal 2, player.albums.size
+    assert_includes player.albums, albums(:confessions)
+    assert_includes player.albums, albums(:peligro)
+  end
+
+  test "not necessarily a player must have an album" do
+    player = Player.new(name: players(:madonna).name)
+    assert player.valid?
+    assert_equal 0, player.albums.size
   end
 
   test "presence of name" do


### PR DESCRIPTION
### Descrição

Problema: O relacionamento entre Albums e Players foi modificado de 1:N para N:N. Agora, um Album pode ter vários Players e, da mesma forma, um Player pode estar vinculado a vários Albums.

Solução: Os modelos foram ajustados para suportar o novo relacionamento. Os testes existentes foram atualizados para refletir a nova lógica, e novos testes foram adicionados para validar os novos cenários. Além disso, o uso das fixtures foi aprimorado para facilitar a leitura dos testes e a revisão do código. Também foi realizada uma migração dos dados existentes para garantir a consistência com a nova estrutura.

### Links e observações

As versões e bibliotecas (gems) foram mantidas, exceto pelo mimemagic, que não possuía mais suporte para a versão previamente utilizada.

### Checklist para poder mergear

- [ ] Alteração nas relacionamento
- [ ] Dados corretamente migrados
- [ ] Validação de cenários de testes e cobertura.
